### PR TITLE
feat: Implement RSS MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# RSS MCP Server
+
+This project is a simple FastAPI server that acts as a proxy for RSS feeds. It exposes a single endpoint to fetch the latest item from a given RSS feed URL, with built-in caching to avoid unnecessary requests to the source feed.
+
+The server also exposes a Model Context Protocol (MCP) endpoint at `/mcp`, allowing AI agents to interact with the RSS proxy functionality.
+
+## Setup
+
+1.  **Create a virtual environment** (optional but recommended):
+    ```bash
+    python -m venv venv
+    source venv/bin/activate
+    ```
+
+2.  **Install dependencies**:
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Running the Server
+
+To run the development server with live reloading:
+```bash
+uvicorn src.api.main:app --reload
+```
+The server will be available at `http://127.0.0.1:8000`.
+
+## Running Tests
+
+To run the full test suite (contract, integration, and unit tests):
+```bash
+pytest
+```
+
+## API Usage
+
+Send a `POST` request to `/api/rss-proxy` with a JSON body containing the feed URL:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://news.yahoo.co.jp/rss/topics/top-picks.xml"
+  }' \
+  http://127.0.0.1:8000/api/rss-proxy
+```
+
+The server will return the latest item from the feed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+feedparser
+listparser
+pytest
+httpx
+fastapi-mcp
+pyyaml
+pytest-mock
+jsonschema

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -27,8 +27,11 @@ async def log_requests(request: Request, call_next):
     )
     return response
 
+from typing import Optional
+
 class RssRequest(BaseModel):
-    url: HttpUrl
+    url: Optional[HttpUrl] = None
+    opml: Optional[str] = None
 
 @app.post("/api/rss-proxy", response_model=FeedItem)
 def proxy_rss_feed(request: RssRequest):

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,59 @@
+import logging
+import time
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel, HttpUrl
+from fastapi_mcp import FastApiMCP
+
+from src.models.feed import FeedItem
+from src.services.rss_proxy_service import get_latest_feed_item, RssProxyServiceError
+
+app = FastAPI(
+    title="RSS MCP Server",
+    version="0.1.0",
+    description="A server to proxy RSS feeds and provide the latest item.",
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    start_time = time.time()
+    response = await call_next(request)
+    process_time = time.time() - start_time
+    logger.info(
+        f"request_path={request.url.path} method={request.method} status_code={response.status_code} duration={process_time:.4f}s"
+    )
+    return response
+
+class RssRequest(BaseModel):
+    url: HttpUrl
+
+@app.post("/api/rss-proxy", response_model=FeedItem)
+def proxy_rss_feed(request: RssRequest):
+    """
+    Accepts an RSS feed URL, fetches the latest item, and returns it.
+    It uses a cache to avoid re-fetching unchanged feeds.
+    """
+    try:
+        feed_item = get_latest_feed_item(request.url)
+        return feed_item
+    except RssProxyServiceError as e:
+        error_str = str(e).lower()
+        if "validation failed" in error_str or "missing a publication date" in error_str:
+            raise HTTPException(status_code=422, detail=f"Invalid data in source feed: {e}")
+
+        if "not well-formed" in error_str or "no entries" in error_str:
+            raise HTTPException(status_code=404, detail=f"Could not parse feed: {e}")
+
+        if "http error" in error_str:
+            raise HTTPException(status_code=404, detail=f"Could not fetch feed: {e}")
+
+        raise HTTPException(status_code=500, detail=f"Internal server error while processing feed: {e}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {e}")
+
+# Mount the MCP server
+mcp = FastApiMCP(app)
+mcp.mount()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -55,7 +55,8 @@ def proxy_rss_feed(request: RssRequest):
 
         raise HTTPException(status_code=500, detail=f"Internal server error while processing feed: {e}")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {e}")
+        logger.error("An unexpected error occurred", exc_info=True)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred")
 
 # Mount the MCP server
 mcp = FastApiMCP(app)

--- a/src/models/feed.py
+++ b/src/models/feed.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from pydantic import BaseModel, HttpUrl
+from typing import Optional
+
+
+class FeedItem(BaseModel):
+    title: str
+    link: HttpUrl
+    published_date: datetime
+    description: str
+
+
+class CacheEntry(BaseModel):
+    feed_url: HttpUrl
+    item: FeedItem
+    last_fetched: datetime
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None

--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -1,0 +1,25 @@
+from typing import Dict, Optional
+
+from src.models.feed import CacheEntry
+
+
+class CacheService:
+    """
+    A simple in-memory cache service for RSS feed entries.
+    """
+    _cache: Dict[str, CacheEntry] = {}
+
+    def get(self, url: str) -> Optional[CacheEntry]:
+        """
+        Retrieves a cache entry for a given URL.
+        """
+        return self._cache.get(url)
+
+    def set(self, url: str, entry: CacheEntry):
+        """
+        Stores a cache entry.
+        """
+        self._cache[url] = entry
+
+# Create a single instance to be used by the application
+cache_service = CacheService()

--- a/src/services/rss_proxy_service.py
+++ b/src/services/rss_proxy_service.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+from pydantic import HttpUrl
+
+from src.lib.rss_parser import parse_feed, FeedParsingError
+from src.services.cache_service import cache_service
+from src.models.feed import FeedItem, CacheEntry
+
+
+class RssProxyServiceError(Exception):
+    """Custom exception for the RSS Proxy service."""
+    pass
+
+
+def get_latest_feed_item(url: HttpUrl) -> FeedItem:
+    """
+    Gets the latest feed item for a given URL, using a cache to avoid
+    unnecessary fetches.
+    """
+    url_str = str(url)
+    cached_entry = cache_service.get(url_str)
+    etag = cached_entry.etag if cached_entry else None
+    last_modified = cached_entry.last_modified if cached_entry else None
+
+    try:
+        new_item, new_etag, new_last_modified = parse_feed(
+            url=url_str, etag=etag, last_modified=last_modified
+        )
+
+        if new_item is None and cached_entry:
+            return cached_entry.item
+
+        if new_item:
+            entry_to_cache = CacheEntry(
+                feed_url=url,
+                item=new_item,
+                last_fetched=datetime.now(timezone.utc),
+                etag=new_etag,
+                last_modified=new_last_modified,
+            )
+            cache_service.set(url_str, entry_to_cache)
+            return new_item
+
+        if cached_entry:
+            return cached_entry.item
+        else:
+            raise RssProxyServiceError("Failed to fetch feed and no cached version available.")
+
+    except FeedParsingError as e:
+        if cached_entry:
+            return cached_entry.item
+        raise RssProxyServiceError(str(e)) from e

--- a/tests/contract/test_api.py
+++ b/tests/contract/test_api.py
@@ -1,0 +1,27 @@
+import yaml
+import pytest
+from fastapi.testclient import TestClient
+from jsonschema import validate
+
+from src.api.main import app
+
+# Load the OpenAPI spec
+with open("specs/001-rss-web-mcp/contracts/api.yaml", "r") as f:
+    openapi_spec = yaml.safe_load(f)
+
+client = TestClient(app)
+
+def test_rss_proxy_contract():
+    """
+    Tests the POST /api/rss-proxy endpoint against its OpenAPI contract.
+    """
+    request_body = {"url": "https://news.yahoo.co.jp/rss/topics/top-picks.xml"}
+    request_schema = openapi_spec["paths"]["/api/rss-proxy"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+    validate(instance=request_body, schema=request_schema)
+
+    response = client.post("/api/rss-proxy", json=request_body)
+
+    assert response.status_code == 200
+
+    response_schema = openapi_spec["components"]["schemas"]["FeedItem"]
+    validate(instance=response.json(), schema=response_schema)

--- a/tests/integration/test_rss_proxy.py
+++ b/tests/integration/test_rss_proxy.py
@@ -1,0 +1,34 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.api.main import app
+
+client = TestClient(app)
+
+VALID_RSS_URL = "https://news.yahoo.co.jp/rss/topics/top-picks.xml"
+INVALID_URL = "not-a-valid-url"
+NOT_A_FEED_URL = "https://example.com"
+
+def test_first_request_to_valid_feed():
+    """
+    Scenario: First request to a valid feed URL.
+    Expected: Returns 200 OK.
+    """
+    response = client.post("/api/rss-proxy", json={"url": VALID_RSS_URL})
+    assert response.status_code == 200
+    assert "title" in response.json()
+
+def test_request_with_invalid_url():
+    """
+    Scenario: A request with an invalid URL.
+    Expected: Returns 422 Unprocessable Entity.
+    """
+    response = client.post("/api/rss-proxy", json={"url": INVALID_URL})
+    assert response.status_code == 422
+
+def test_request_with_non_feed_url():
+    """
+    Scenario: A request for a URL that is not a valid RSS feed.
+    Expected: Returns 404 Not Found.
+    """
+    response = client.post("/api/rss-proxy", json={"url": NOT_A_FEED_URL})
+    assert response.status_code == 404

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1,0 +1,42 @@
+import pytest
+from datetime import datetime, timezone
+from pydantic import HttpUrl
+
+from src.services.cache_service import CacheService
+from src.models.feed import CacheEntry, FeedItem
+
+@pytest.fixture
+def cache_service():
+    """
+    Provides a clean instance of the CacheService for each test.
+    """
+    service = CacheService()
+    service._cache = {}
+    yield service
+    service._cache = {}
+
+@pytest.fixture
+def sample_cache_entry():
+    """Provides a sample CacheEntry for testing."""
+    return CacheEntry(
+        feed_url=HttpUrl("http://example.com/rss"),
+        item=FeedItem(
+            title="Test Title",
+            link=HttpUrl("http://example.com/item1"),
+            published_date=datetime.now(timezone.utc),
+            description="Test Description"
+        ),
+        last_fetched=datetime.now(timezone.utc),
+        etag="test-etag"
+    )
+
+def test_set_and_get_entry(cache_service, sample_cache_entry):
+    url = str(sample_cache_entry.feed_url)
+    cache_service.set(url, sample_cache_entry)
+    retrieved_entry = cache_service.get(url)
+    assert retrieved_entry is not None
+    assert retrieved_entry == sample_cache_entry
+
+def test_get_nonexistent_entry(cache_service):
+    retrieved_entry = cache_service.get("http://nonexistent.com/rss")
+    assert retrieved_entry is None

--- a/tests/unit/test_rss_parser.py
+++ b/tests/unit/test_rss_parser.py
@@ -1,0 +1,54 @@
+import pytest
+import httpx
+from datetime import datetime, timezone
+
+from src.lib.rss_parser import parse_feed, FeedParsingError
+from src.models.feed import FeedItem
+
+SAMPLE_RSS_CONTENT = """
+<rss version="2.0">
+<channel>
+  <title>Test Feed</title>
+  <item>
+    <title>Test Item 1</title>
+    <link>http://example.com/item1</link>
+    <pubDate>Sun, 07 Sep 2025 12:00:00 GMT</pubDate>
+    <description>This is a test item.</description>
+  </item>
+</channel>
+</rss>
+"""
+
+@pytest.fixture
+def mock_httpx_client(mocker):
+    return mocker.patch("httpx.Client")
+
+def test_parse_feed_success(mock_httpx_client):
+    mock_response = httpx.Response(
+        200,
+        content=SAMPLE_RSS_CONTENT,
+        headers={"ETag": "new-etag"},
+        request=httpx.Request("GET", "http://example.com/rss")
+    )
+    mock_httpx_client.return_value.__enter__.return_value.get.return_value = mock_response
+    item, etag, _ = parse_feed("http://example.com/rss")
+    assert isinstance(item, FeedItem)
+    assert item.title == "Test Item 1"
+    assert etag == "new-etag"
+
+def test_parse_feed_not_modified(mock_httpx_client):
+    mock_response = httpx.Response(304, request=httpx.Request("GET", "http://example.com/rss"))
+    mock_httpx_client.return_value.__enter__.return_value.get.return_value = mock_response
+    item, _, _ = parse_feed("http://example.com/rss", etag="old-etag")
+    assert item is None
+
+def test_parse_feed_http_error(mock_httpx_client):
+    mock_httpx_client.return_value.__enter__.return_value.get.side_effect = httpx.RequestError("Mocked error")
+    with pytest.raises(FeedParsingError, match="HTTP error"):
+        parse_feed("http://example.com/rss")
+
+def test_parse_feed_malformed(mock_httpx_client):
+    mock_response = httpx.Response(200, content="<rss", request=httpx.Request("GET", "http://example.com/rss"))
+    mock_httpx_client.return_value.__enter__.return_value.get.return_value = mock_response
+    with pytest.raises(FeedParsingError, match="not well-formed"):
+        parse_feed("http://example.com/rss")


### PR DESCRIPTION
This commit introduces a complete RSS proxy server based on the specifications in `specs/001-rss-web-mcp/`.

The implementation includes:
- A FastAPI application with a `/api/rss-proxy` endpoint.
- A robust RSS parsing library that handles various feed inconsistencies.
- An in-memory caching service to reduce load on source feeds.
- A service layer to orchestrate parsing and caching logic.
- Integration with `fastapi-mcp` to expose the endpoint as an MCP tool.
- Structured logging middleware for observability.
- A comprehensive test suite, including contract, integration, and unit tests.
- A README file with setup and usage instructions.

The project follows a test-driven development (TDD) approach and is structured with a clear separation of concerns.